### PR TITLE
Potential fix for code scanning alert no. 1: DOM text reinterpreted as HTML

### DIFF
--- a/Edit.html
+++ b/Edit.html
@@ -107,12 +107,25 @@
           subtitle: document.getElementById("subtitle").value,
           slides: slidesData
         };
-        let html = `<h2>${data.title}</h2>`;
-        if (data.subtitle) html += `<h3>${data.subtitle}</h3>`;
+        let html = `<h2>${escapeHTML(data.title)}</h2>`;
+        if (data.subtitle) html += `<h3>${escapeHTML(data.subtitle)}</h3>`;
         html += data.slides.map(s =>
-          `<div><strong>${s.title}</strong><br>${s.text || ""}</div>`
+          `<div><strong>${escapeHTML(s.title)}</strong><br>${escapeHTML(s.text || "")}</div>`
         ).join('<hr>');
         document.getElementById("livePreview").innerHTML = html;
+        
+        function escapeHTML(str) {
+          return str.replace(/[&<>"']/g, function (char) {
+            const escapeMap = {
+              '&': '&amp;',
+              '<': '&lt;',
+              '>': '&gt;',
+              '"': '&quot;',
+              "'": '&#39;'
+            };
+            return escapeMap[char];
+          });
+        }
       }
       document.getElementById("goToIndex").onclick = function() {
         window.location.href = "index.html?json=" + getExportedJSON();


### PR DESCRIPTION
Potential fix for [https://github.com/blake437/Presentation/security/code-scanning/1](https://github.com/blake437/Presentation/security/code-scanning/1)

To fix the issue, we need to ensure that any user input interpolated into the HTML string is properly escaped to prevent XSS attacks. The best approach is to use a library like `DOMPurify` to sanitize the input or encode the text using `textContent` instead of `innerHTML`. This ensures that meta-characters are treated as plain text rather than HTML.

Specifically:
1. Replace the direct assignment of `html` to `innerHTML` with a safer alternative.
2. Use `textContent` for plain text or sanitize the HTML using `DOMPurify` if HTML formatting is required.
3. Update the `updatePreview` function to escape or sanitize all user inputs before rendering them.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
