### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/Lint.yml
+++ b/.github/workflows/Lint.yml
@@ -6,6 +6,9 @@ on:
   push:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/blake437/Presentation/security/code-scanning/4](https://github.com/blake437/Presentation/security/code-scanning/4)

To fix the issue, we will add a `permissions` block at the root level of the workflow file. This block will explicitly set the `contents` permission to `read`, which is sufficient for the linting tasks performed in this workflow. This ensures that the workflow does not have unnecessary write permissions, reducing the risk of misuse.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
