### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/summary.yml
+++ b/.github/workflows/summary.yml
@@ -95,6 +95,8 @@ jobs:
   write_fixes_and_prs:
     needs: list_fixes
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:


### PR DESCRIPTION
Potential fix for [https://github.com/blake437/Presentation/security/code-scanning/6](https://github.com/blake437/Presentation/security/code-scanning/6)

To fix the issue, we need to add an explicit `permissions` block to the `write_fixes_and_prs` job. This block should specify the minimal permissions required for the job to function correctly. Based on the job's actions (e.g., creating branches, committing changes, and pushing them), the `contents: write` permission is necessary. Other permissions, such as `issues: write`, are not required for this job and should not be included.

The `permissions` block should be added immediately after the `runs-on` key in the `write_fixes_and_prs` job definition.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
