### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/summary.yml
+++ b/.github/workflows/summary.yml
@@ -84,6 +84,8 @@ jobs:
   list_fixes:
     needs: run_ai
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
       - run: |


### PR DESCRIPTION
Potential fix for [https://github.com/blake437/Presentation/security/code-scanning/5](https://github.com/blake437/Presentation/security/code-scanning/5)

To fix the issue, we will add a `permissions` block to the `list_fixes` job. Since this job only processes files locally and does not interact with GitHub resources using the `GITHUB_TOKEN`, it requires no special permissions. Therefore, we will set the permissions to `contents: read`, which is the minimal permission required for most workflows.

The changes will be made in the `.github/workflows/summary.yml` file, specifically within the `list_fixes` job definition.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
